### PR TITLE
search for ForeignSecurityPrincipals already implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ More examples can be found in [USAGE.md](USAGE.md).
 
 * [ ] Adapt the package so it could be used independently (in CLI or as a package to import)
 * [ ] look for new vulnerable configuration to add: <https://youtu.be/7_iv_eaAFyQ>
-* [ ] implement a search for ForeignSecurityPrincipals (When a user/group from an *external* domain/forest are added to a group in a domain, an object of type foreignSecurityPrincipal is created at `CN=<user_SID>,CN=ForeignSecurityPrincipals,DC=domain,DC=com`)
 
 Done:
 
@@ -68,6 +67,7 @@ Done:
 * [x] give useful `search` examples (see <https://phonexicum.github.io/infosec/windows.html> and <https://blog.xpnsec.com/kerberos-attacks-part-2/>)
 * [x] add a command to get vulnerable users to AS-REP-roasting (thanks [@HadrienPerrineau](https://github.com/HadrienPerrineau))
 * [x] change the core architecture to create an object and do not open multiple connection for `-t all`
+* [x] search for ForeignSecurityPrincipals (When a user/group from an *external* domain/forest are added to a group in a domain, an object of type foreignSecurityPrincipal is created at `CN=<user_SID>,CN=ForeignSecurityPrincipals,DC=domain,DC=com`)
 
 ## Contributions
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -335,6 +335,24 @@ $ ./ldapsearch-ad.py -l 192.168.56.20 -d evilcorp -u jjohnny -p 'P@$$word' -t me
 
 Note: it is also possible to look for multiple groups by using wildcard (e.g. `-s 'grp-admin*'`), but it is limited to the first 100 groups for the moment.
 
+
+### search for ForeignSecurityPrincipals
+
+Requesting the global catalog (port 3268) to get the list of external principals added to a group in the current forest.
+
+``` text
+$ ./ldapsearch-ad.py -l 192.168.56.20:3268 -d evilcorp -u jjohnny -p 'P@$$word' -t search -s '(objectClass=foreignSecurityPrincipal)'
+### Result of "search" command ###
+[+] |___cn = S-1-5-4
+[+] |___distinguishedName = CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=evilcorp,DC=>
+[+] |___name = S-1-5-4
+[+] |___objectCategory = CN=Foreign-Security-Principal,CN=Schema,CN=Configuration,DC=evilcorp>
+[+] |___objectClass = ['top', 'foreignSecurityPrincipal']
+[+] |___objectGUID = {4c9260f3-ab5a-4ef3-829d-2f6a33a3deaa}
+[+] |___objectSid = S-1-5-4
+[…]
+```
+
 ## Authenticate with an NTLM hash instead of a password
 
 Because sometimes the compromise is still on-going.

--- a/USAGE.md
+++ b/USAGE.md
@@ -336,7 +336,7 @@ $ ./ldapsearch-ad.py -l 192.168.56.20 -d evilcorp -u jjohnny -p 'P@$$word' -t me
 Note: it is also possible to look for multiple groups by using wildcard (e.g. `-s 'grp-admin*'`), but it is limited to the first 100 groups for the moment.
 
 
-### search for ForeignSecurityPrincipals
+### Search for Foreign Security Principals members
 
 List Security Principals (Users, Computers and groups) in external or forest trusts that are members of domain local scope groups in the current forest by requesting the global catalog on port 3268.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -336,20 +336,17 @@ $ ./ldapsearch-ad.py -l 192.168.56.20 -d evilcorp -u jjohnny -p 'P@$$word' -t me
 Note: it is also possible to look for multiple groups by using wildcard (e.g. `-s 'grp-admin*'`), but it is limited to the first 100 groups for the moment.
 
 
-### Search for Foreign Security Principals members
+### -t search-foreign-security-principals
 
 List Security Principals (Users, Computers and groups) in external or forest trusts that are members of domain local scope groups in the current forest by requesting the global catalog on port 3268.
 
 ``` text
-$ ./ldapsearch-ad.py -l 192.168.56.20:3268 -d evilcorp -u jjohnny -p 'P@$$word' -t search -s '(objectClass=foreignSecurityPrincipal)'
-### Result of "search" command ###
-[+] |___cn = S-1-5-4
-[+] |___distinguishedName = CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=evilcorp>
-[+] |___name = S-1-5-4
-[+] |___objectCategory = CN=Foreign-Security-Principal,CN=Schema,CN=Configuration,DC=evilcorp>
-[+] |___objectClass = ['top', 'foreignSecurityPrincipal']
-[+] |___objectGUID = {4c9260f3-ab5a-4ef3-829d-2f6a33a3deaa}
+$ ./ldapsearch-ad.py -l 192.168.56.20 -n 3268 -d evilcorp -u jjohnny -p 'P@$$word' -t search-foreign-security-principals
+### Result of "search-foreign-security-principals" command ###
+[+] name = S-1-5-4
 [+] |___objectSid = S-1-5-4
+[+] |___distinguishedName = CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=evilcorp>
+[+] |___objectClass = ['top', 'foreignSecurityPrincipal']}
 […]
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -344,7 +344,7 @@ Requesting the global catalog (port 3268) to get the list of external principals
 $ ./ldapsearch-ad.py -l 192.168.56.20:3268 -d evilcorp -u jjohnny -p 'P@$$word' -t search -s '(objectClass=foreignSecurityPrincipal)'
 ### Result of "search" command ###
 [+] |___cn = S-1-5-4
-[+] |___distinguishedName = CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=evilcorp,DC=>
+[+] |___distinguishedName = CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=evilcorp>
 [+] |___name = S-1-5-4
 [+] |___objectCategory = CN=Foreign-Security-Principal,CN=Schema,CN=Configuration,DC=evilcorp>
 [+] |___objectClass = ['top', 'foreignSecurityPrincipal']

--- a/USAGE.md
+++ b/USAGE.md
@@ -338,7 +338,7 @@ Note: it is also possible to look for multiple groups by using wildcard (e.g. `-
 
 ### search for ForeignSecurityPrincipals
 
-Requesting the global catalog (port 3268) to get the list of external principals added to a group in the current forest.
+List Security Principals (Users, Computers and groups) in external or forest trusts that are members of domain local scope groups in the current forest by requesting the global catalog on port 3268.
 
 ``` text
 $ ./ldapsearch-ad.py -l 192.168.56.20:3268 -d evilcorp -u jjohnny -p 'P@$$word' -t search -s '(objectClass=foreignSecurityPrincipal)'

--- a/ldapsearch-ad.py
+++ b/ldapsearch-ad.py
@@ -24,7 +24,7 @@ def main():
         "-l", "--server", dest="ldap_server", help="IP address of the LDAP server."
     )
     arg_parser.add_argument(
-        "-n", "--port", dest="server_port_number", help="Port number to request (389 (LDAP), 636 (LDAP over SSL), 3268 (GC), 3269 (GC over SSL))."
+        "-n", "--port", dest="server_port_number", type=int, help="Port number to request (389 (LDAP), 636 (LDAP over SSL), 3268 (GC), 3269 (GC over SSL))."
     )
     arg_parser.add_argument(
         "-ssl",
@@ -39,7 +39,7 @@ def main():
         dest="request_type",
         help="Request type: info, whoami, search, trusts,\
         pass-pols, admins, show-user, show-user-list, kerberoast, search-spn, asreproast, goldenticket,\
-        search-delegation, createsid, seach-foreign-security-principals, all",
+        search-delegation, createsid, search-foreign-security-principals, all",
     )
     arg_parser.add_argument(
         "-d",
@@ -121,7 +121,7 @@ def main():
     mandatory_arguments["goldenticket"] = ["domain", "username"]
     mandatory_arguments["search-delegation"] = ["domain", "username"]
     mandatory_arguments["createsid"] = ["domain", "username"]
-    mandatory_arguments["seach-foreign-security-principals"] = ["domain", "username"]
+    mandatory_arguments["search-foreign-security-principals"] = ["domain", "username"]
     mandatory_arguments["all"] = ["domain", "username"]
     actions = [i.strip() for i in args.request_type.split(",")]
     for action in actions:
@@ -230,9 +230,9 @@ def main():
             ldap.print_member_of(args.search_filter, args.size_limit)
 
         # Get list of Foreign Security Principals added to domain local groups from external/forest trusts 
-        elif action == "seach-foreign-security-principals":
-            log_title('Result of "seach-foreign-security-principals" command', 3)
-            ldap.print_seach_foreign_security_principals(args.size_limit)
+        elif action == "search-foreign-security-principals":
+            log_title('Result of "search-foreign-security-principals" command', 3)
+            ldap.print_search_foreign_security_principals(args.size_limit)
 
         # Get trusts
         elif action == "trusts":

--- a/ldapsearch-ad.py
+++ b/ldapsearch-ad.py
@@ -24,6 +24,9 @@ def main():
         "-l", "--server", dest="ldap_server", help="IP address of the LDAP server."
     )
     arg_parser.add_argument(
+        "-n", "--port", dest="server_port_number", help="Port number to request (389 (LDAP), 636 (LDAP over SSL), 3268 (GC), 3269 (GC over SSL))."
+    )
+    arg_parser.add_argument(
         "-ssl",
         "--ssl",
         dest="ssl",
@@ -36,7 +39,7 @@ def main():
         dest="request_type",
         help="Request type: info, whoami, search, trusts,\
         pass-pols, admins, show-user, show-user-list, kerberoast, search-spn, asreproast, goldenticket,\
-        search-delegation, createsid, all",
+        search-delegation, createsid, seach-foreign-security-principals, all",
     )
     arg_parser.add_argument(
         "-d",
@@ -118,6 +121,7 @@ def main():
     mandatory_arguments["goldenticket"] = ["domain", "username"]
     mandatory_arguments["search-delegation"] = ["domain", "username"]
     mandatory_arguments["createsid"] = ["domain", "username"]
+    mandatory_arguments["seach-foreign-security-principals"] = ["domain", "username"]
     mandatory_arguments["all"] = ["domain", "username"]
     actions = [i.strip() for i in args.request_type.split(",")]
     for action in actions:
@@ -154,6 +158,7 @@ def main():
     # Connection to the LDAP server using credentials provided in argument
     ldap = LdapsearchAd(
         args.ldap_server,
+        args.server_port_number,
         args.ssl,
         args.domain,
         args.username,
@@ -223,6 +228,11 @@ def main():
         elif action == "member-of":
             log_title('Result of "member-of" command', 3)
             ldap.print_member_of(args.search_filter, args.size_limit)
+
+        # Get list of Foreign Security Principals added to domain local groups from external/forest trusts 
+        elif action == "seach-foreign-security-principals":
+            log_title('Result of "seach-foreign-security-principals" command', 3)
+            ldap.print_seach_foreign_security_principals(args.size_limit)
 
         # Get trusts
         elif action == "trusts":

--- a/ldapsearchad/ldapsearchad.py
+++ b/ldapsearchad/ldapsearchad.py
@@ -329,7 +329,7 @@ class LdapsearchAd:
             log_info(f'name = {sp["name"]}')
             log_info(f'|__ objectSid = {sp["objectSid"]}')
             log_info(f'|__ distinguishedName = {sp["distinguishedName"]}')
-            log_info(f'|__objectClass = {sp["objectClass"]}')
+            log_info(f'|__ objectClass = {sp["objectClass"]}')
 
     def print_trusts(self):
         """Method to get infos about trusts."""

--- a/ldapsearchad/ldapsearchad.py
+++ b/ldapsearchad/ldapsearchad.py
@@ -29,6 +29,7 @@ from .utils import convert_sid_to_string
 class LdapsearchAd:
 
     hostname = None
+    port = None
     domain = None
     username = None
     password = None
@@ -40,6 +41,8 @@ class LdapsearchAd:
     def __init__(
         self,
         hostname,
+        #default ldaps port if not specified
+        port=636,
         ssl=False,
         domain=None,
         username=None,
@@ -47,6 +50,7 @@ class LdapsearchAd:
         hashes=None,
     ):
         self.hostname = hostname
+        self.port = port
         self.domain = domain
         self.username = username
         self.password = password
@@ -55,7 +59,7 @@ class LdapsearchAd:
             self.lmhash, self.nthash = self.hashes.split(":")
 
         try:
-            self.server = ldap3.Server(self.hostname, use_ssl=ssl, get_info="ALL")
+            self.server = ldap3.Server(self.hostname, self.port, use_ssl=ssl, get_info="ALL")
             if self.domain and self.username:
                 if self.password:
                     self.connection = ldap3.Connection(
@@ -309,6 +313,19 @@ class LdapsearchAd:
             users = self.search(search_filter, attributes, size_limit=size_limit)
             for user in users:
                 self.__print_user_brief(user, "    ")
+
+    def print_seach_foreign_security_principals(self, size_limit=100):
+        """Print the list of foreign security principals who are members 
+        domain local groups in the current forest"""
+        search_filter = f"(objectClass=foreignSecurityPrincipal)"
+        attributes = [
+            "name",
+            "objectSid",
+            "distinguishedName"
+        ]
+        fsp = self.search(search_filter, attributes, size_limit=size_limit)
+        for sp in fsp:
+            self.__print_user_brief(sp, "    ")
 
     def print_trusts(self):
         """Method to get infos about trusts."""

--- a/ldapsearchad/ldapsearchad.py
+++ b/ldapsearchad/ldapsearchad.py
@@ -314,18 +314,22 @@ class LdapsearchAd:
             for user in users:
                 self.__print_user_brief(user, "    ")
 
-    def print_seach_foreign_security_principals(self, size_limit=100):
+    def print_search_foreign_security_principals(self, size_limit=100):
         """Print the list of foreign security principals who are members 
         domain local groups in the current forest"""
-        search_filter = f"(objectClass=foreignSecurityPrincipal)"
+        search_filter = f"(objectclass=foreignSecurityPrincipal)"
         attributes = [
             "name",
             "objectSid",
-            "distinguishedName"
+            "distinguishedName",
+            "objectClass"
         ]
         fsp = self.search(search_filter, attributes, size_limit=size_limit)
         for sp in fsp:
-            self.__print_user_brief(sp, "    ")
+            log_info(f'name = {sp["name"]}')
+            log_info(f'|__ objectSid = {sp["objectSid"]}')
+            log_info(f'|__ distinguishedName = {sp["distinguishedName"]}')
+            log_info(f'|__objectClass = {sp["objectClass"]}')
 
     def print_trusts(self):
         """Method to get infos about trusts."""


### PR DESCRIPTION
Hello, 

Thanks a lot for this great tool! 

While I was working on group scopes and memberships, I needed to get the list of external/forest trust members of a group in a domain and I used `ldapsearch-ad` for that. As it uses ldap3 to handle requests, I saw that it was possible to specify the port number and have the requests addressed the global catalog instead, which contains some useful information about external membership in domain local groups (very minimum actually but still useful for Recon). 

Here is the way I did to retrieve the information hoping it is useful. 

Best regards,