### PR TITLE
Read username, password, and hashes from file if it exists

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -349,6 +349,11 @@ $ ./ldapsearch-ad.py -l 192.168.56.20 -n 3268 -d evilcorp -u jjohnny -p 'P@$$wor
 [+] |___objectClass = ['top', 'foreignSecurityPrincipal']}
 […]
 ```
+## Authenticate with credentials in a file instead of in the commandline
+```bash
+./ldapsearch-ad.py -l 192.168.56.20 -d evilcorp -u username.txt -p username.txt -t info
+./ldapsearch-ad.py -l 192.168.56.20 -d evilcorp -u username.txt -H hash.txt -t info
+```
 
 ## Authenticate with an NTLM hash instead of a password
 

--- a/ldapsearch-ad.py
+++ b/ldapsearch-ad.py
@@ -6,6 +6,8 @@ import logging
 from sys import exit
 from sys import stdout
 
+from os import path as os_path
+
 from ldapsearchad import LdapsearchAd
 from ldapsearchad import version as ldapsearchad_version
 
@@ -166,15 +168,23 @@ def main():
         logger.addHandler(f_handler)
     logger.addHandler(handler)
 
+    # Read username, password, and hashes from file if it exists
+    def read_from_file_if_exists(arg):
+        if arg is not None and os_path.isfile(arg):
+            with open(arg) as fin:
+                return fin.readline().rstrip()
+        else:
+            return arg
+
     # Connection to the LDAP server using credentials provided in argument
     ldap = LdapsearchAd(
         args.ldap_server,
         args.server_port_number,
         args.ssl,
         args.domain,
-        args.username,
-        args.password,
-        args.hashes,
+        read_from_file_if_exists(args.username),
+        read_from_file_if_exists(args.password),
+        read_from_file_if_exists(args.hashes),
     )
 
     for action in actions:


### PR DESCRIPTION
This allows more opsec-safe commands

I actually assumed this was existing functionality at first (just because of other tools working the same way) and couldn't figure out why my commands weren't working:

![image](https://github.com/yaap7/ldapsearch-ad/assets/34610663/1aac6691-9d6e-4743-9ecc-82644b580dbb)

New functionality after changes:

![image](https://github.com/yaap7/ldapsearch-ad/assets/34610663/d089c914-c31b-4375-872a-4594228618f7)


**Notes**:

A couple things to note about this:
- If you have a file in the cwd that is the name of the username or password you're passing in, it will read from that file instead of from the terminal. I'm okay with this, but it's something to note before merging the PR
- I didn't add this functionality for anything other than `username`, `password`, and `hashes`, but I'm open to changing that.